### PR TITLE
Adds Bristlecone packet to wrap Clone concept

### DIFF
--- a/BristleconeWorldSubsystem.cpp
+++ b/BristleconeWorldSubsystem.cpp
@@ -21,8 +21,8 @@ void UBristleconeWorldSubsystem::OnWorldBeginPlay(UWorld& InWorld) {
 						.AsNonBlocking()
 						.AsReusable()
 						.BoundToEndpoint(local_endpoint)
-						.WithReceiveBufferSize(PACKET_SIZE)
-						.WithSendBufferSize(PACKET_SIZE)
+						.WithReceiveBufferSize(CONTROLLER_STATE_PACKET_SIZE)
+						.WithSendBufferSize(CONTROLLER_STATE_PACKET_SIZE)
 						.Build());
 		
 		// Start sender thread

--- a/FBristleconePacket.h
+++ b/FBristleconePacket.h
@@ -1,0 +1,94 @@
+﻿#pragma once
+
+template<
+	typename CLONE_TYPE,
+	unsigned int CLONE_SIZE>
+class FBristleconePacket;
+
+/**
+ * Acts as a wrapper to manipulate the contents of a packet for networking
+ * 
+ * @tparam CLONE_TYPE 
+ * @tparam CLONE_SIZE 
+ */
+template<
+	typename CLONE_TYPE,
+	unsigned int CLONE_SIZE>
+class FBristleconePacketContainer {
+public:
+	FBristleconePacketContainer(): clone_state_ring_index(0) {
+	}
+
+	void InsertNewDatagram(const CLONE_TYPE* new_datagram) {
+		// Update array with new data
+		CLONE_TYPE* newest_element = packet.GetPointerToElement(clone_state_ring_index);
+		memcpy(newest_element, new_datagram, sizeof(CLONE_TYPE));
+		packet.UpdateTransferTime();
+
+		// Update index
+		clone_state_ring_index = (clone_state_ring_index + 1) % CLONE_SIZE;
+	}
+
+	FBristleconePacket<CLONE_TYPE, CLONE_SIZE>* GetPacket() {
+		return &packet;
+	}
+
+	FDateTime GetTransferTime() const {
+		return packet.GetTransferTime();
+	}
+
+private:
+	uint32 clone_state_ring_index;
+	FBristleconePacket<CLONE_TYPE, CLONE_SIZE> packet;
+};
+
+/**
+ * A Bristlecone packet, hereafter called a clone, contains at least the most recent datagram that we want to send
+ * plus a history containing CLONE_SIZE - 1 datagrams
+ * 
+ * @tparam CLONE_TYPE Type used in the datagram.
+ * @tparam CLONE_SIZE Count representing the number of datagrams to send with a single clone
+ */
+template<
+	typename CLONE_TYPE,
+	unsigned int CLONE_SIZE>
+class FBristleconePacket {
+public:
+	FBristleconePacket() {
+		Clear();
+	}
+
+	void Clear() {
+		memset(clone_array, 0, sizeof(CLONE_TYPE) * CLONE_SIZE);
+	}
+
+	FDateTime GetTransferTime() const {
+		return transfer_time;
+	}
+	
+	void UpdateTransferTime() {
+		transfer_time = FDateTime::Now();
+	}
+
+	CLONE_TYPE* GetPointerToElement(uint32 element_index) {
+		return &clone_array[element_index];
+	}
+
+	FString ToString() const {
+		FString output;// = FString::Printf(TEXT("Transfer time = %s, array = "), *transfer_time.ToString());
+		output += "Transfer time = ";
+		output += transfer_time.ToString();
+		output += ", array = "; 
+		for (uint32 array_index = 0; array_index < CLONE_SIZE; array_index++) {
+			output += clone_array[array_index].ToString();
+			output += " ";
+		}
+		return output;
+	}
+
+private:
+	// Packet headers
+	FDateTime transfer_time;
+	// Data clone
+	CLONE_TYPE clone_array[CLONE_SIZE];
+};

--- a/FBristleconeSender.cpp
+++ b/FBristleconeSender.cpp
@@ -6,13 +6,6 @@
 FBristleconeSender::FBristleconeSender() : running(false) {
 	UE_LOG(LogTemp, Display, TEXT("Bristlecone:Sender: Constructing Bristlecone Sender"));
 
-	// Datagram clone
-	clone_state_ring_index = 0;
-	for (uint32 ring_idx = 0; ring_idx < CLONE_SIZE; ++ring_idx) {
-		clone_state_ring[ring_idx].clear();
-	}
-	
-	// Endpoints
 	target_endpoints.Reserve(MAX_TARGET_COUNT);
 }
 
@@ -47,25 +40,19 @@ uint32 FBristleconeSender::Run() {
 		// Update ring array
 		counter++;
 		sending_state.controller_arr[0] = counter;
-		clone_state_ring_index = (clone_state_ring_index + 1) % CLONE_SIZE;
-		clone_state_ring[clone_state_ring_index].controller_arr[0] = counter;
+		packet_container.InsertNewDatagram(&sending_state);
 		
 		for (auto& endpoint : target_endpoints) {
 			int32 bytes_sent;
 
-			uint8 send_attempts_made = 0;
-			for (uint32 clone_send_index = (clone_state_ring_index + 1) % CLONE_SIZE;
-				send_attempts_made < 3 && running;
-				clone_send_index = (clone_send_index + 1) % CLONE_SIZE) {
-				const FControllerState* current_controller_state = &clone_state_ring[clone_send_index];
+			const FControllerStatePacket* current_controller_state = packet_container.GetPacket();
 
-				const bool packet_sent = sender_socket->SendTo(reinterpret_cast<const uint8*>(current_controller_state->controller_arr), sizeof(FControllerState),
-				                                               bytes_sent, *endpoint.ToInternetAddr());
-				UE_LOG(LogTemp, Warning, TEXT("Sent message: %s : %s : Address - %s : BytesSent - %d"), *current_controller_state->to_string(),
-					   (packet_sent ? TEXT("true") : TEXT("false")), *endpoint.ToString(), bytes_sent);
-				running = packet_sent && bytes_sent > 0;
-				send_attempts_made++;
-			}
+			const bool packet_sent = sender_socket->SendTo(reinterpret_cast<const uint8*>(current_controller_state), sizeof(FControllerStatePacket),
+														   bytes_sent, *endpoint.ToInternetAddr());
+			UE_LOG(LogTemp, Warning, TEXT("Sent message: %s : %s : Address - %s : BytesSent - %d"), *current_controller_state->ToString(),
+				   (packet_sent ? TEXT("true") : TEXT("false")), *endpoint.ToString(), bytes_sent);
+			
+			running = packet_sent && bytes_sent > 0;
 		}
 
 		FPlatformProcess::Sleep(0.1f);

--- a/FBristleconeSender.h
+++ b/FBristleconeSender.h
@@ -1,4 +1,5 @@
 ﻿#pragma once
+#include "FBristleconePacket.h"
 #include "FControllerState.h"
 #include "Interfaces/IPv4/IPv4Endpoint.h"
 
@@ -20,13 +21,10 @@ public:
 
 private:
 	void Cleanup();
+
+	FBristleconePacketContainer<FControllerState, 3> packet_container;
 	
-	uint32 clone_state_ring_index;
-	FControllerState clone_state_ring[CLONE_SIZE];
-	
-	//TUniquePtr<FSocket> sender_socket;
 	TSharedPtr<FSocket, ESPMode::ThreadSafe> sender_socket;
-	//FIPv4Endpoint local_endpoint;
 	TArray<FIPv4Endpoint> target_endpoints;
 
 	TUniquePtr<ISocketSubsystem> socket_subsystem;

--- a/FControllerState.h
+++ b/FControllerState.h
@@ -13,7 +13,7 @@ public:
 		memset(controller_arr, 0, sizeof(FControllerState));
 	}
 
-	FString to_string() const {
+	FString ToString() const {
 		return FString::Printf(TEXT("{ %d, %d, %d, %d }"), controller_arr[0], controller_arr[1], controller_arr[2], controller_arr[3]);
 	}
 };

--- a/UBristleconeWorldSubsystem.h
+++ b/UBristleconeWorldSubsystem.h
@@ -3,13 +3,15 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "FBristleconePacket.h"
 #include "FBristleconeReceiver.h"
 #include "FBristleconeSender.h"
 #include "Subsystems/WorldSubsystem.h"
 #include "UBristleconeWorldSubsystem.generated.h"
 
-// TODO - Update to header_size + (data_packet * CLONE_COUNT)
-static constexpr int PACKET_SIZE = 2 * 1024 * 1024;
+typedef FBristleconePacket<FControllerState, 3> FControllerStatePacket;
+
+static constexpr int CONTROLLER_STATE_PACKET_SIZE = sizeof(FControllerStatePacket);
 static constexpr int DEFAULT_PORT = 40000;
 static constexpr uint16 MAX_TARGET_COUNT = 1;
 


### PR DESCRIPTION
Adds timestamp so we can start testing total round trip times

Moves some packet stuff to templates so that we can expand to non-controller schemas later