### PR TITLE
Synchronize sleep times across sender and receiver threads

### DIFF
--- a/FBristleconeReceiver.cpp
+++ b/FBristleconeReceiver.cpp
@@ -44,7 +44,7 @@ uint32 FBristleconeReceiver::Run() {
 			UE_LOG(LogTemp, Warning, TEXT("Received %s in %d bytes from target in %d milliseconds"), *receiving_state.GetPacket()->ToString(), bytes_read, round_trip_time.GetFractionMilli());
 		}
 
-		FPlatformProcess::Sleep(0.1f);
+		FPlatformProcess::Sleep(SLEEP_TIME_BETWEEN_THREAD_TICKS);
 	}
 	
 	return 0;

--- a/FBristleconeSender.h
+++ b/FBristleconeSender.h
@@ -4,6 +4,7 @@
 #include "Interfaces/IPv4/IPv4Endpoint.h"
 
 static constexpr uint8 CLONE_SIZE = 3;
+static constexpr uint8 MAX_MIXED_CONSECUTIVE_PACKETS_ALLOWED = 100;
 
 class FBristleconeSender : public FRunnable {
 public:
@@ -28,6 +29,8 @@ private:
 	TArray<FIPv4Endpoint> target_endpoints;
 
 	TUniquePtr<ISocketSubsystem> socket_subsystem;
+
+	uint8 consecutive_zero_bytes_sent;
 
 	bool running;
 };

--- a/UBristleconeWorldSubsystem.h
+++ b/UBristleconeWorldSubsystem.h
@@ -14,6 +14,7 @@ typedef FBristleconePacket<FControllerState, 3> FControllerStatePacket;
 static constexpr int CONTROLLER_STATE_PACKET_SIZE = sizeof(FControllerStatePacket);
 static constexpr int DEFAULT_PORT = 40000;
 static constexpr uint16 MAX_TARGET_COUNT = 1;
+static constexpr float SLEEP_TIME_BETWEEN_THREAD_TICKS = 0.01f;
 
 UCLASS()
 class BRISTLECONEWORK_API UBristleconeWorldSubsystem : public UTickableWorldSubsystem


### PR DESCRIPTION
Allow for missed update frames on send.