### PR TITLE
Some small bug fixes and cleanup

### DIFF
--- a/Source/Bristlecone/Private/FCabling.cpp
+++ b/Source/Bristlecone/Private/FCabling.cpp
@@ -28,7 +28,6 @@ bool FCabling::Init() {
 
 //this is based directly on the gameinput sample code.
 uint32 FCabling::Run() {
-
 	IGameInput* g_gameInput = nullptr;
 	HRESULT gameInputSpunUp = GameInputCreate(&g_gameInput);
 	IGameInputDevice* g_gamepad = nullptr;
@@ -111,7 +110,7 @@ uint32 FCabling::Run() {
 				}
 
 			}
-			else
+			else if (g_gamepad != nullptr)
 			{
 				g_gamepad->Release();
 				g_gamepad = nullptr;

--- a/Source/Bristlecone/Public/UBristleconeWorldSubsystem.h
+++ b/Source/Bristlecone/Public/UBristleconeWorldSubsystem.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "FBristleconePacket.h"
 #include "FBristleconeReceiver.h"
 #include "FBristleconeSender.h"
 #include "Subsystems/WorldSubsystem.h"
@@ -16,8 +15,6 @@
 //of UObjects, but for now, I'm leaving it. My use-cases only require the 8byte.
 #include "UBristleconeWorldSubsystem.generated.h"
 using namespace TheCone;
-
-
 
 UCLASS()
 class BRISTLECONE_API UBristleconeWorldSubsystem : public UTickableWorldSubsystem
@@ -55,13 +52,11 @@ public:
 
   private:
 	FIPv4Endpoint local_endpoint;
-	const UBristleconeConstants* ConfigVals;
+
 	TSharedPtr<FSocket, ESPMode::ThreadSafe> socketHigh;
 	TSharedPtr<FSocket, ESPMode::ThreadSafe> socketLow;
 	TSharedPtr<FSocket, ESPMode::ThreadSafe> socketBackground;
 	
-
-
 	// Sender information
   	FBristleconeSender sender_runner;
   	TUniquePtr<FRunnableThread> sender_thread;

--- a/Source/Bristlecone/Public/UCablingWorldSubsystem.h
+++ b/Source/Bristlecone/Public/UCablingWorldSubsystem.h
@@ -30,7 +30,7 @@ protected:
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	virtual void OnWorldBeginPlay(UWorld& InWorld) override;
 	virtual void Deinitialize() override;
-	virtual void PostInitialize();
+	virtual void PostInitialize() override;
 	virtual void Tick(float DeltaTime) override;
 	virtual TStatId GetStatId() const override;
 


### PR DESCRIPTION
UCablingWorldSubsystem.h
* Adds override identifier to UCablingWorldSubsystem::PostInitialize

UBristleconeWorldSubsystem.h
* Removes UBristleconeWorldSubsystem::ConfigVals member variable

UBristleconeWorldSubsystem.cpp
* Moves ConfigVals to local variable in UBristleconeWorldSubsystem::Initialize as we are not holding onto it anymore
* Assigns address to sender_runner in UBristleconeWorldSubsystem::Initialize

FCabling.cpp
* Adds null check to g_gamepad->Release block